### PR TITLE
Add quick web control panel for simplified management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DB_URL=postgresql://app:app@postgres:5432/control_personal
+JWT_SECRET=devsecret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install backend deps
+        run: |
+          cd backend-node
+          npm install
+      - name: Run backend tests
+        run: |
+          cd backend-node
+          npm test -- --runInBand
+      - name: Install frontend deps
+        run: |
+          cd app
+          npm install
+      - name: Build frontend
+        run: |
+          cd app
+          npm run build
+  publish:
+    needs: build-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build backend image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}-backend:latest"
+          docker build -t "$IMAGE" backend-node
+          docker push "$IMAGE"
+      - name: Build frontend image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}-frontend:latest"
+          docker build -t "$IMAGE" app
+          docker push "$IMAGE"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+.env
+.DS_Store
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+dist
+coverage
+*.log
+app/node_modules
+backend-node/node_modules
+control-personal-full.zip
+control-personal-full.b64

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: build up down seed
+
+build:
+docker compose build
+
+up:
+docker compose up -d --build
+docker compose logs -f --tail=50
+
+down:
+docker compose down
+
+seed:
+docker compose run --rm backend-node npm run seed

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# PositionSystem.Bertero2.0v
+# Sistema General de Control de Personal en Tiempo Real
+
+Paquete autosuficiente que orquesta backend Node.js, frontend React y PostgreSQL para monitorear personal en vivo. Se ejecuta íntegramente en contenedores y se administra mediante una SPA.
+
+## Requisitos
+- Docker y Docker Compose v2
+- Make (opcional, facilita comandos)
+
+## Puesta en marcha
+```bash
+cp .env.example .env
+cp app/.env.example app/.env
+docker compose up -d --build
+```
+
+La base se inicializa automáticamente con esquemas y semillas. Accesos principales:
+- SPA: http://localhost:5173
+- API/diagnóstico: http://localhost:8080/health
+
+Para detener los servicios: `docker compose down`
+
+### Makefile útil
+- `make build`
+- `make up`
+- `make down`
+- `make seed` (reinyecta semillas desde el backend)
+
+## API
+La documentación OpenAPI se encuentra en [`openapi.yaml`](./openapi.yaml). Endpoints clave: autenticación, personas, eventos de presencia, estados en vivo, reportes KPI y alertas de prueba. Incluye ejemplos y definición de errores esperados.
+
+## Arquitectura
+- **Backend** (`backend-node/`): Express, WebSocket y motor de estados puro que resuelve conflictos por prioridad (EMERGENCY > BIOMETRIC > GEOFENCE > TASK > CALENDAR). Publica eventos en `/ws/status` para actualizaciones en tiempo real. Tests con Jest (motor + contrato básico).
+- **Frontend** (`app/`): React + TypeScript + Vite + Tailwind + React Query + React Hook Form + Zod + TanStack Table + Recharts. Incluye onboarding institucional, configuración, CRUD e importación CSV de personas, sandbox de eventos, dashboard en vivo, auditoría y diagnóstico.
+- **DB** (`db/`): PostgreSQL con tablas `person`, `shift`, `presence_event`, `status_snapshot`, `site`, `audit_log`. Seeds con usuarios de ejemplo.
+- **Infra**: Docker Compose (sin campo `version`) y Makefile. CI publica imágenes en GHCR.
+
+### Escalabilidad futura
+Para analítica avanzada, puede agregarse ClickHouse replicando los eventos desde PostgreSQL. Documentar en infra un conector (p.ej. Debezium + Kafka) que replique `presence_event` para consultas OLAP.
+
+### Monitoreo en tiempo real
+El frontend consume el WebSocket `/ws/status` y cae a polling de 3 segundos si no hay conectividad. Los cambios también se reflejan en la tabla y gráficos del dashboard.
+
+## Tests
+Desde el backend:
+```bash
+cd backend-node
+npm install
+npm test
+```
+
+## CI/CD
+El workflow [`ci.yml`](.github/workflows/ci.yml) construye las imágenes y las publica en GHCR (`ghcr.io/<OWNER>/<REPO>-backend:latest` y `ghcr.io/<OWNER>/<REPO>-frontend:latest`). El token estándar `GITHUB_TOKEN` es suficiente para el push.
+
+## Tips operativos
+- Los seeds ejecutados por Docker cargan personas y estados iniciales.
+- La plantilla CSV está en `app/src/assets/plantilla_personas.csv`.
+- TTL recomendado para `presence_event`: ejecutar periódicamente `DELETE FROM presence_event WHERE ts < NOW() - INTERVAL '90 days';` o configurar `pg_cron`.
+
+## Licencia
+MIT (puede ajustarse según necesidades de la institución).

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package.json package-lock.json* .npmrc* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Control de Personal en Tiempo Real</title>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  include /etc/nginx/mime.types;
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "control-personal-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.4.2",
+    "@tanstack/react-query": "^5.51.21",
+    "@tanstack/react-table": "^8.20.5",
+    "axios": "^1.7.2",
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.51.5",
+    "react-router-dom": "^6.23.1",
+    "recharts": "^2.7.3",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react-swc": "^3.7.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { NavLink, Route, Routes } from 'react-router-dom';
+import Dashboard from './routes/Dashboard';
+import QuickPanel from './routes/QuickPanel';
+import Settings from './routes/Settings';
+import People from './routes/People';
+import ImportCsv from './routes/ImportCsv';
+import Events from './routes/Events';
+import Audit from './routes/Audit';
+import Diagnostics from './routes/Diagnostics';
+import { login } from './lib/api';
+
+const navItems = [
+  { to: '/', label: 'Dashboard', end: true },
+  { to: '/panel', label: 'Panel rápido' },
+  { to: '/configuracion', label: 'Configuración' },
+  { to: '/personas', label: 'Personas' },
+  { to: '/importar', label: 'Importar CSV' },
+  { to: '/eventos', label: 'Sandbox de eventos' },
+  { to: '/auditoria', label: 'Auditoría' },
+  { to: '/diagnostico', label: 'Diagnóstico' },
+];
+
+const App = () => {
+  useEffect(() => {
+    const ensureToken = async () => {
+      const token = localStorage.getItem('token');
+      if (!token) {
+        await login('admin@demo', 'admin');
+      }
+    };
+    ensureToken();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <header className="bg-white shadow">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <h1 className="text-xl font-semibold">Control de Personal en Tiempo Real</h1>
+          <nav className="flex gap-4 text-sm">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                end={item.end}
+                className={({ isActive }) =>
+                  `rounded px-3 py-2 font-medium transition ${isActive ? 'bg-primary text-white' : 'text-slate-600 hover:bg-slate-100'}`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-7xl px-6 py-8">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/panel" element={<QuickPanel />} />
+          <Route path="/configuracion" element={<Settings />} />
+          <Route path="/personas" element={<People />} />
+          <Route path="/importar" element={<ImportCsv />} />
+          <Route path="/eventos" element={<Events />} />
+          <Route path="/auditoria" element={<Audit />} />
+          <Route path="/diagnostico" element={<Diagnostics />} />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/app/src/assets/plantilla_personas.csv
+++ b/app/src/assets/plantilla_personas.csv
@@ -1,0 +1,3 @@
+nombre,rol,jerarquia,especialidad,unidad
+Ana Fernández,Supervisor,Nivel 2,Operaciones,Unidad A
+Bruno Díaz,Operador,Nivel 1,Soporte,Unidad A

--- a/app/src/components/Cards.tsx
+++ b/app/src/components/Cards.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export const StatCard = ({ title, value, subtitle, accent }: { title: string; value: ReactNode; subtitle?: string; accent?: string }) => (
+  <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+    <p className="text-sm font-medium text-slate-500">{title}</p>
+    <p className={`mt-2 text-3xl font-semibold ${accent ?? 'text-slate-900'}`}>{value}</p>
+    {subtitle && <p className="mt-1 text-xs text-slate-400">{subtitle}</p>}
+  </div>
+);
+
+export default StatCard;

--- a/app/src/components/Charts.tsx
+++ b/app/src/components/Charts.tsx
@@ -1,0 +1,23 @@
+import { Pie, PieChart, ResponsiveContainer, Tooltip, Cell } from 'recharts';
+
+const COLORS = ['#0a7cff', '#12b76a', '#f79009', '#f04438', '#8b5cf6', '#0f172a', '#06b6d4', '#f97316'];
+
+export type ChartDatum = { name: string; value: number };
+
+export const StatusPie = ({ data }: { data: ChartDatum[] }) => (
+  <div className="h-64 w-full rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+    <h3 className="text-sm font-semibold text-slate-600">Distribución de estados</h3>
+    <ResponsiveContainer width="100%" height="100%">
+      <PieChart>
+        <Pie dataKey="value" data={data} nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+          {data.map((entry, index) => (
+            <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(value: number) => `${value} personas`} />
+      </PieChart>
+    </ResponsiveContainer>
+  </div>
+);
+
+export default StatusPie;

--- a/app/src/components/FormControls.tsx
+++ b/app/src/components/FormControls.tsx
@@ -1,0 +1,33 @@
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+export const Label = ({ htmlFor, children }: { htmlFor: string; children: ReactNode }) => (
+  <label htmlFor={htmlFor} className="text-sm font-medium text-slate-700">
+    {children}
+  </label>
+);
+
+export const Input = ({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) => (
+  <input
+    className={clsx(
+      'w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20',
+      className
+    )}
+    {...props}
+  />
+);
+
+export const Select = ({ className, children, ...props }: InputHTMLAttributes<HTMLSelectElement> & { children: ReactNode }) => (
+  <select
+    className={clsx(
+      'w-full rounded border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+);
+
+export const ErrorText = ({ message }: { message?: string }) =>
+  message ? <p className="text-sm text-danger">{message}</p> : null;

--- a/app/src/components/Table.tsx
+++ b/app/src/components/Table.tsx
@@ -1,0 +1,39 @@
+import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
+
+export type TableProps<T extends object> = {
+  data: T[];
+  columns: ColumnDef<T, any>[];
+};
+
+export function DataTable<T extends object>({ data, columns }: TableProps<T>) {
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-200 text-sm">
+        <thead className="bg-slate-50">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id} scope="col" className="px-4 py-3 text-left font-semibold text-slate-600">
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody className="divide-y divide-slate-100 bg-white">
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id} className="hover:bg-slate-50">
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="px-4 py-2 text-slate-700">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {data.length === 0 && <p className="p-4 text-center text-sm text-slate-400">Sin resultados</p>}
+    </div>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+:focus-visible {
+  outline: 2px solid theme('colors.primary');
+  outline-offset: 2px;
+}

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export const login = async (username: string, password: string) => {
+  const { data } = await api.post('/auth/login', { username, password });
+  localStorage.setItem('token', data.token);
+  return data;
+};
+
+export const fetchPeople = async (params?: Record<string, string>) => {
+  const { data } = await api.get('/people', { params });
+  return data.data;
+};
+
+export const createPerson = async (payload: Record<string, unknown>) => {
+  const { data } = await api.post('/people', payload);
+  return data;
+};
+
+export const fetchStatusNow = async (unit?: string) => {
+  const { data } = await api.get('/status/now', { params: unit ? { unit } : undefined });
+  return data.data;
+};
+
+export const fetchStatusHistory = async (personId: string) => {
+  const { data } = await api.get('/status/history', { params: { person_id: personId } });
+  return data.data;
+};
+
+export const postPresenceEvent = async (payload: Record<string, unknown>) => {
+  const { data } = await api.post('/events/presence', payload);
+  return data;
+};
+
+export const fetchAudit = async (personId: string) => {
+  const { data } = await api.get(`/audit/${personId}`);
+  return data.data;
+};
+
+export const fetchKpi = async (params?: Record<string, string>) => {
+  const { data } = await api.get('/reports/kpi', { params });
+  return data.totals;
+};
+
+export const fetchHealth = async () => {
+  const { data } = await api.get('/health');
+  return data;
+};
+
+export default api;

--- a/app/src/lib/validators.ts
+++ b/app/src/lib/validators.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const personSchema = z.object({
+  nombre: z.string().min(1, 'Nombre obligatorio'),
+  rol: z.string().min(1, 'Rol obligatorio'),
+  jerarquia: z.string().optional(),
+  especialidad: z.string().optional(),
+  unidad: z.string().optional(),
+});
+
+export const presenceEventSchema = z.object({
+  person_id: z.string().min(1, 'Persona obligatoria'),
+  ts: z.string().min(1, 'Timestamp requerido'),
+  source: z.enum(['mobile', 'kiosk', 'biometric', 'task', 'calendar', 'panic']),
+  type: z.enum(['entry', 'exit', 'checkin', 'checkout', 'assigned', 'completed', 'panic', 'geo_enter', 'geo_exit']),
+  payload: z.union([z.string(), z.record(z.any())]).optional(),
+});
+
+export const institutionSchema = z.object({
+  nombre: z.string().min(1, 'Nombre obligatorio'),
+  zonaHoraria: z.string().min(1, 'Zona horaria requerida'),
+  toleranciaNoShow: z.number().min(0),
+  breakMax: z.number().min(0),
+  prefijoLegajo: z.string().min(1),
+});

--- a/app/src/lib/ws.ts
+++ b/app/src/lib/ws.ts
@@ -1,0 +1,61 @@
+import { fetchStatusNow } from './api';
+
+type Listener = (data: unknown) => void;
+
+class StatusChannel {
+  private listeners: Set<Listener> = new Set();
+  private ws?: WebSocket;
+  private interval?: number;
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      this.init();
+    }
+  }
+
+  private init() {
+    try {
+      const url = new URL(import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080');
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+      url.pathname = '/ws/status';
+      this.ws = new WebSocket(url.toString());
+      this.ws.onmessage = (event) => {
+        const payload = JSON.parse(event.data);
+        if (payload.type === 'status_update') {
+          this.emit(payload.payload);
+        }
+      };
+      this.ws.onclose = () => {
+        this.startPolling();
+      };
+    } catch (error) {
+      console.warn('WS no disponible, fallback a polling', error);
+      this.startPolling();
+    }
+  }
+
+  private startPolling() {
+    if (this.interval) return;
+    this.interval = window.setInterval(async () => {
+      try {
+        const data = await fetchStatusNow();
+        this.emit(data);
+      } catch (error) {
+        console.warn('Polling falló', error);
+      }
+    }, 3000);
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(data: unknown) {
+    this.listeners.forEach((listener) => listener(data));
+  }
+}
+
+export const statusChannel = new StatusChannel();

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchAudit } from '../lib/api';
+import { Input, Label } from '../components/FormControls';
+
+const Audit = () => {
+  const [personId, setPersonId] = useState('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+  const { data = [], refetch, isFetching } = useQuery({
+    queryKey: ['audit', personId],
+    queryFn: () => fetchAudit(personId),
+  });
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Auditoría por persona</h2>
+        <div className="mt-4 flex gap-4">
+          <div className="flex-1 space-y-2">
+            <Label htmlFor="persona">Persona (UUID)</Label>
+            <Input id="persona" value={personId} onChange={(event) => setPersonId(event.target.value)} />
+          </div>
+          <button
+            type="button"
+            className="self-end rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow"
+            onClick={() => refetch()}
+          >
+            Consultar
+          </button>
+        </div>
+        <ul className="mt-6 space-y-3 text-sm">
+          {data.map((item: any) => (
+            <li key={item.ts} className="border-l-2 border-primary pl-4">
+              <p className="font-semibold">{item.action}</p>
+              <p className="text-slate-500">{new Date(item.ts).toLocaleString()}</p>
+              <pre className="rounded bg-slate-100 p-2 text-xs text-slate-600">{JSON.stringify(item.details, null, 2)}</pre>
+            </li>
+          ))}
+          {data.length === 0 && !isFetching && <li className="text-slate-400">Sin auditoría disponible</li>}
+          {isFetching && <li className="text-slate-400">Cargando…</li>}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default Audit;

--- a/app/src/routes/Dashboard.tsx
+++ b/app/src/routes/Dashboard.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchStatusNow, postPresenceEvent } from '../lib/api';
+import { statusChannel } from '../lib/ws';
+import { DataTable } from '../components/Table';
+import { StatCard } from '../components/Cards';
+import StatusPie from '../components/Charts';
+
+const STATUS_LABELS: Record<string, string> = {
+  OFF_SHIFT: 'Fuera de turno',
+  ON_SHIFT: 'En turno',
+  AVAILABLE: 'Disponible',
+  BUSY: 'Ocupado',
+  BREAK: 'En descanso',
+  ABSENT: 'Ausente',
+  TRAINING: 'Capacitación',
+  ESCALATED: 'Escalado',
+  EMERGENCY: 'Emergencia',
+};
+
+const Dashboard = () => {
+  const queryClient = useQueryClient();
+  const { data: initialData = [] } = useQuery({
+    queryKey: ['status-now'],
+    queryFn: () => fetchStatusNow(),
+  });
+  const [rows, setRows] = useState(initialData);
+
+  useEffect(() => {
+    setRows(initialData);
+  }, [initialData]);
+
+  useEffect(() => {
+    const unsubscribe = statusChannel.subscribe((data) => {
+      if (Array.isArray(data)) {
+        setRows(data as typeof rows);
+      } else if (data && typeof data === 'object' && 'person_id' in (data as Record<string, unknown>)) {
+        setRows((prev) => {
+          const snapshot = data as { person_id: string; status: string; ts: string; reason?: string };
+          const idx = prev.findIndex((item) => item.id === snapshot.person_id);
+          if (idx >= 0) {
+            const next = [...prev];
+            next[idx] = { ...next[idx], status: snapshot.status, ts: snapshot.ts, reason: snapshot.reason };
+            return next;
+          }
+          queryClient.invalidateQueries({ queryKey: ['status-now'] });
+          return prev;
+        });
+      }
+    });
+    return unsubscribe;
+  }, [queryClient]);
+
+  const totals = useMemo(() => {
+    const counts: Record<string, number> = {};
+    rows.forEach((row) => {
+      counts[row.status] = (counts[row.status] || 0) + 1;
+    });
+    return counts;
+  }, [rows]);
+
+  const chartData = useMemo(
+    () =>
+      Object.entries(totals).map(([status, value]) => ({
+        name: STATUS_LABELS[status] ?? status,
+        value,
+      })),
+    [totals]
+  );
+
+  const mutation = useMutation({
+    mutationFn: (input: { person_id: string; type: string }) =>
+      postPresenceEvent({
+        person_id: input.person_id,
+        ts: new Date().toISOString(),
+        source: 'task',
+        type: input.type,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['status-now'] });
+    },
+  });
+
+  const columns = useMemo(
+    () => [
+      {
+        header: 'Nombre',
+        accessorKey: 'nombre',
+      },
+      {
+        header: 'Rol',
+        accessorKey: 'rol',
+      },
+      {
+        header: 'Unidad',
+        accessorKey: 'unidad',
+      },
+      {
+        header: 'Estado',
+        accessorKey: 'status',
+        cell: ({ getValue }: any) => STATUS_LABELS[getValue()] ?? getValue(),
+      },
+      {
+        header: 'Actualizado',
+        accessorKey: 'ts',
+        cell: ({ getValue }: any) => new Date(getValue()).toLocaleTimeString(),
+      },
+      {
+        header: 'Acciones',
+        cell: ({ row }: any) => (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-200"
+              onClick={() => mutation.mutate({ person_id: row.original.id, type: 'assigned' })}
+            >
+              Escalar
+            </button>
+            <button
+              type="button"
+              className="rounded bg-slate-100 px-2 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-200"
+              onClick={() => mutation.mutate({ person_id: row.original.id, type: 'completed' })}
+            >
+              Fin tarea
+            </button>
+          </div>
+        ),
+      },
+    ],
+    [mutation]
+  );
+
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-4 md:grid-cols-4">
+        <StatCard title="Activos" value={rows.length} subtitle="Personas con estado reciente" />
+        <StatCard title="Disponibles" value={totals.AVAILABLE ?? 0} accent="text-success" />
+        <StatCard title="En emergencia" value={totals.EMERGENCY ?? 0} accent="text-danger" />
+        <StatCard title="En descanso" value={totals.BREAK ?? 0} accent="text-amber-500" />
+      </section>
+      <section className="grid gap-4 lg:grid-cols-[2fr,3fr]">
+        <StatusPie data={chartData} />
+        <div>
+          <h2 className="mb-4 text-lg font-semibold">Personas</h2>
+          <DataTable data={rows} columns={columns as any} />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/app/src/routes/Diagnostics.tsx
+++ b/app/src/routes/Diagnostics.tsx
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchHealth } from '../lib/api';
+import { useState } from 'react';
+
+const Diagnostics = () => {
+  const [lastChecked, setLastChecked] = useState<string | null>(null);
+  const { data, refetch, isFetching } = useQuery({
+    queryKey: ['health'],
+    queryFn: async () => {
+      const result = await fetchHealth();
+      setLastChecked(new Date().toLocaleString());
+      return result;
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Diagnóstico del backend</h2>
+        <p className="text-sm text-slate-500">Último chequeo: {lastChecked ?? 'nunca'}</p>
+        <button
+          type="button"
+          className="mt-4 rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow"
+          onClick={() => refetch()}
+          disabled={isFetching}
+        >
+          {isFetching ? 'Verificando…' : 'Refrescar'}
+        </button>
+        {data && (
+          <dl className="mt-6 grid gap-4 text-sm">
+            <div>
+              <dt className="text-slate-500">Estado</dt>
+              <dd className="font-semibold text-success">{data.status}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Latencia (ms)</dt>
+              <dd className="font-semibold">{data.latency_ms}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Versión</dt>
+              <dd className="font-semibold">{data.version}</dd>
+            </div>
+          </dl>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Diagnostics;

--- a/app/src/routes/Events.tsx
+++ b/app/src/routes/Events.tsx
@@ -1,0 +1,119 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation } from '@tanstack/react-query';
+import { presenceEventSchema } from '../lib/validators';
+import { postPresenceEvent, fetchStatusHistory } from '../lib/api';
+import { Label, Input, Select, ErrorText } from '../components/FormControls';
+import { useState } from 'react';
+import { z } from 'zod';
+
+const Events = () => {
+  const [history, setHistory] = useState<any[]>([]);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<z.infer<typeof presenceEventSchema>>({
+    resolver: zodResolver(presenceEventSchema),
+    defaultValues: {
+      ts: new Date().toISOString().slice(0, 16),
+      source: 'mobile',
+      type: 'checkin',
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (payload: z.infer<typeof presenceEventSchema>) => postPresenceEvent(payload),
+    onSuccess: async (_, variables) => {
+      const data = await fetchStatusHistory(variables.person_id);
+      setHistory(data);
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof presenceEventSchema>) => {
+    const parsedValues = { ...values, ts: new Date(values.ts).toISOString() };
+    if (values.payload && typeof values.payload === 'string') {
+      try {
+        parsedValues.payload = JSON.parse(values.payload as unknown as string);
+      } catch (error) {
+        parsedValues.payload = { raw: values.payload };
+      }
+    }
+    mutation.mutate(parsedValues);
+    setValue('ts', new Date().toISOString().slice(0, 16));
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.5fr,1fr]">
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Sandbox de eventos de presencia</h2>
+        <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
+          <div className="space-y-2">
+            <Label htmlFor="person_id">Persona (UUID)</Label>
+            <Input id="person_id" {...register('person_id')} placeholder="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" />
+            <ErrorText message={errors.person_id?.message} />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="ts">Timestamp</Label>
+              <Input id="ts" type="datetime-local" {...register('ts')} />
+              <ErrorText message={errors.ts?.message} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="source">Origen</Label>
+              <Select id="source" {...register('source')}>
+                <option value="mobile">Mobile</option>
+                <option value="kiosk">Kiosco</option>
+                <option value="biometric">Biométrico</option>
+                <option value="task">Tarea</option>
+                <option value="calendar">Calendario</option>
+                <option value="panic">Pánico</option>
+              </Select>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="type">Tipo de evento</Label>
+            <Select id="type" {...register('type')}>
+              <option value="checkin">Check-in</option>
+              <option value="checkout">Check-out</option>
+              <option value="entry">Entrada</option>
+              <option value="exit">Salida</option>
+              <option value="assigned">Asignado</option>
+              <option value="completed">Completado</option>
+              <option value="panic">Pánico</option>
+              <option value="geo_enter">Geocerca entrada</option>
+              <option value="geo_exit">Geocerca salida</option>
+            </Select>
+            <ErrorText message={errors.type?.message} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="payload">Payload JSON (opcional)</Label>
+            <Input id="payload" placeholder='{"detalle":"valor"}' {...register('payload')} />
+          </div>
+          <button type="submit" className="rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow" disabled={mutation.isLoading}>
+            {mutation.isLoading ? 'Enviando…' : 'Enviar evento'}
+          </button>
+          {mutation.isError && <p className="text-sm text-danger">Error al enviar evento</p>}
+          {mutation.isSuccess && <p className="text-sm text-success">Evento aplicado</p>}
+        </form>
+      </section>
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Historial reciente</h2>
+        <p className="text-sm text-slate-500">Se actualiza automáticamente tras registrar un evento.</p>
+        <ul className="mt-4 space-y-3 text-sm">
+          {history.map((item) => (
+            <li key={item.ts} className="rounded border border-slate-200 p-3">
+              <p className="font-semibold">{item.status}</p>
+              <p className="text-slate-500">{new Date(item.ts).toLocaleString()}</p>
+              <p className="text-slate-400">{item.reason}</p>
+            </li>
+          ))}
+          {history.length === 0 && <li className="text-slate-400">Sin eventos todavía</li>}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default Events;

--- a/app/src/routes/ImportCsv.tsx
+++ b/app/src/routes/ImportCsv.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createPerson } from '../lib/api';
+import templateUrl from '../assets/plantilla_personas.csv?url';
+
+interface CsvRow {
+  nombre: string;
+  rol: string;
+  jerarquia?: string;
+  especialidad?: string;
+  unidad?: string;
+}
+
+const ImportCsv = () => {
+  const [rows, setRows] = useState<CsvRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (items: CsvRow[]) => {
+      for (const row of items) {
+        await createPerson(row);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['people'] });
+      setStatus('Importación completada');
+    },
+  });
+
+  const parseCsv = async (file: File) => {
+    const text = await file.text();
+    const lines = text.trim().split(/\r?\n/);
+    if (lines.length < 2) {
+      setError('El archivo debe incluir encabezado y al menos una fila');
+      return;
+    }
+    const headers = lines[0].split(',').map((h) => h.trim());
+    const requiredHeaders = ['nombre', 'rol'];
+    if (!requiredHeaders.every((header) => headers.includes(header))) {
+      setError('El CSV debe incluir las columnas nombre y rol');
+      return;
+    }
+    const parsedRows: CsvRow[] = lines.slice(1).map((line) => {
+      const values = line.split(',');
+      const row: Record<string, string> = {};
+      headers.forEach((header, index) => {
+        row[header] = values[index]?.trim() ?? '';
+      });
+      return row as CsvRow;
+    });
+    setRows(parsedRows.filter((row) => row.nombre));
+    setError(null);
+    setStatus(null);
+  };
+
+  const handleImport = () => {
+    if (rows.length === 0) {
+      setError('No hay filas válidas para importar');
+      return;
+    }
+    mutation.mutate(rows);
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Importar desde CSV</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Descargá la{' '}
+          <a href={templateUrl} className="text-primary underline">
+            plantilla
+          </a>{' '}
+          y cargala con tus datos.
+        </p>
+        <input
+          type="file"
+          accept="text/csv"
+          className="mt-4"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) parseCsv(file);
+          }}
+        />
+        {error && <p className="mt-3 text-sm text-danger">{error}</p>}
+        {status && <p className="mt-3 text-sm text-success">{status}</p>}
+        {rows.length > 0 && (
+          <div className="mt-4 space-y-2">
+            <h3 className="font-semibold">Vista previa ({rows.length} filas)</h3>
+            <div className="max-h-64 overflow-auto rounded border border-slate-200">
+              <table className="min-w-full text-sm">
+                <thead className="bg-slate-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Nombre</th>
+                    <th className="px-3 py-2 text-left">Rol</th>
+                    <th className="px-3 py-2 text-left">Unidad</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row, index) => (
+                    <tr key={index} className="odd:bg-white even:bg-slate-50">
+                      <td className="px-3 py-2">{row.nombre}</td>
+                      <td className="px-3 py-2">{row.rol}</td>
+                      <td className="px-3 py-2">{row.unidad}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <button
+              type="button"
+              className="rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow"
+              onClick={handleImport}
+              disabled={mutation.isLoading}
+            >
+              {mutation.isLoading ? 'Importando…' : 'Importar'}
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default ImportCsv;

--- a/app/src/routes/People.tsx
+++ b/app/src/routes/People.tsx
@@ -1,0 +1,113 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createPerson, fetchPeople } from '../lib/api';
+import { DataTable } from '../components/Table';
+import { Label, Input, Select, ErrorText } from '../components/FormControls';
+import { personSchema } from '../lib/validators';
+import { z } from 'zod';
+import { useMemo, useState } from 'react';
+
+const People = () => {
+  const queryClient = useQueryClient();
+  const [filters, setFilters] = useState<{ unidad?: string; rol?: string }>({});
+  const { data = [], isFetching } = useQuery({
+    queryKey: ['people', filters],
+    queryFn: () => fetchPeople(filters as Record<string, string>),
+  });
+
+  const columns = useMemo(
+    () => [
+      { header: 'Nombre', accessorKey: 'nombre' },
+      { header: 'Rol', accessorKey: 'rol' },
+      { header: 'Unidad', accessorKey: 'unidad' },
+      { header: 'Especialidad', accessorKey: 'especialidad' },
+    ],
+    []
+  );
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<z.infer<typeof personSchema>>({ resolver: zodResolver(personSchema) });
+
+  const mutation = useMutation({
+    mutationFn: (values: z.infer<typeof personSchema>) => createPerson(values),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['people'] });
+      reset();
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof personSchema>) => mutation.mutate(values);
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Alta rápida</h2>
+        <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSubmit(onSubmit)}>
+          <div className="space-y-2">
+            <Label htmlFor="nombre">Nombre</Label>
+            <Input id="nombre" {...register('nombre')} />
+            <ErrorText message={errors.nombre?.message} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="rol">Rol</Label>
+            <Input id="rol" {...register('rol')} />
+            <ErrorText message={errors.rol?.message} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="jerarquia">Jerarquía</Label>
+            <Input id="jerarquia" {...register('jerarquia')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="especialidad">Especialidad</Label>
+            <Input id="especialidad" {...register('especialidad')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="unidad">Unidad</Label>
+            <Input id="unidad" {...register('unidad')} />
+          </div>
+          <div className="flex items-end">
+            <button type="submit" className="rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow">
+              Crear persona
+            </button>
+          </div>
+        </form>
+      </section>
+      <section className="space-y-4">
+        <div className="flex flex-wrap gap-4">
+          <div className="space-y-1">
+            <Label htmlFor="filtroUnidad">Filtrar por unidad</Label>
+            <Select
+              id="filtroUnidad"
+              value={filters.unidad ?? ''}
+              onChange={(event) => setFilters((prev) => ({ ...prev, unidad: event.target.value || undefined }))}
+            >
+              <option value="">Todas</option>
+              <option value="Unidad A">Unidad A</option>
+              <option value="Unidad B">Unidad B</option>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="filtroRol">Filtrar por rol</Label>
+            <Select id="filtroRol" value={filters.rol ?? ''} onChange={(event) => setFilters((prev) => ({ ...prev, rol: event.target.value || undefined }))}>
+              <option value="">Todos</option>
+              <option value="Supervisor">Supervisor</option>
+              <option value="Operador">Operador</option>
+            </Select>
+          </div>
+        </div>
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Personas registradas</h2>
+          {isFetching && <p className="text-sm text-slate-400">Actualizando…</p>}
+        </div>
+        <DataTable data={data} columns={columns as any} />
+      </section>
+    </div>
+  );
+};
+
+export default People;

--- a/app/src/routes/QuickPanel.tsx
+++ b/app/src/routes/QuickPanel.tsx
@@ -1,0 +1,533 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createPerson,
+  fetchPeople,
+  fetchStatusNow,
+  postPresenceEvent,
+} from '../lib/api';
+
+const personSchema = z.object({
+  nombre: z.string().min(1, 'Ingresá un nombre'),
+  rol: z.string().min(1, 'Indicá el rol'),
+  jerarquia: z.string().optional(),
+  especialidad: z.string().optional(),
+  unidad: z.string().min(1, 'Seleccioná una unidad'),
+});
+
+const eventSchema = z.object({
+  person_id: z.string().min(1, 'Elegí a la persona'),
+  ts: z.string().min(1, 'Definí el momento'),
+  source: z.enum(['mobile', 'kiosk', 'biometric', 'task', 'calendar', 'panic']),
+  type: z.enum([
+    'entry',
+    'exit',
+    'checkin',
+    'checkout',
+    'assigned',
+    'completed',
+    'panic',
+    'geo_enter',
+    'geo_exit',
+  ]),
+  payload: z.string().optional(),
+});
+
+type PersonForm = z.infer<typeof personSchema>;
+type EventForm = z.infer<typeof eventSchema>;
+
+type PersonRow = {
+  id: string | number;
+  nombre: string;
+  rol: string;
+};
+
+type StatusRow = {
+  id: string | number;
+  nombre: string;
+  rol: string | null;
+  unidad: string | null;
+  status: string | null;
+  reason: string | null;
+  ts: string | null;
+};
+
+const sources = [
+  { value: 'biometric', label: 'Biométrico' },
+  { value: 'mobile', label: 'Móvil' },
+  { value: 'kiosk', label: 'Totem/Kiosco' },
+  { value: 'task', label: 'Tarea' },
+  { value: 'calendar', label: 'Calendario' },
+  { value: 'panic', label: 'Pánico' },
+];
+
+const types = [
+  { value: 'entry', label: 'Entrada' },
+  { value: 'exit', label: 'Salida' },
+  { value: 'checkin', label: 'Check-in' },
+  { value: 'checkout', label: 'Check-out' },
+  { value: 'assigned', label: 'Asignada' },
+  { value: 'completed', label: 'Completada' },
+  { value: 'panic', label: 'Botón de pánico' },
+  { value: 'geo_enter', label: 'Entrada a zona' },
+  { value: 'geo_exit', label: 'Salida de zona' },
+];
+
+const QuickPanel = () => {
+  const queryClient = useQueryClient();
+  const [personMessage, setPersonMessage] = useState<string | null>(null);
+  const [eventMessage, setEventMessage] = useState<string | null>(null);
+  const [eventError, setEventError] = useState<string | null>(null);
+
+  const peopleQuery = useQuery({
+    queryKey: ['people', { panel: true }],
+    queryFn: () => fetchPeople(),
+  });
+
+  const statusQuery = useQuery({
+    queryKey: ['status-now', { panel: true }],
+    queryFn: () => fetchStatusNow(),
+    refetchInterval: 3000,
+  });
+
+  const {
+    register: registerPerson,
+    handleSubmit: handleSubmitPerson,
+    reset: resetPerson,
+    formState: { errors: personErrors },
+  } = useForm<PersonForm>({
+    resolver: zodResolver(personSchema),
+    defaultValues: {
+      nombre: '',
+      rol: '',
+      jerarquia: '',
+      especialidad: '',
+      unidad: '',
+    },
+  });
+
+  const nowLocal = () => new Date().toISOString().slice(0, 16);
+
+  const {
+    register: registerEvent,
+    handleSubmit: handleSubmitEvent,
+    reset: resetEvent,
+    formState: { errors: eventErrors },
+  } = useForm<EventForm>({
+    resolver: zodResolver(eventSchema),
+    defaultValues: {
+      person_id: '',
+      ts: nowLocal(),
+      source: 'biometric',
+      type: 'entry',
+      payload: '',
+    },
+  });
+
+  const createPersonMutation = useMutation({
+    mutationFn: (values: PersonForm) => createPerson(values),
+    onSuccess: (created) => {
+      setPersonMessage(`Persona ${created.nombre} registrada`);
+      queryClient.invalidateQueries({ queryKey: ['people'] });
+      queryClient.invalidateQueries({ queryKey: ['status-now'] });
+      resetPerson();
+    },
+  });
+
+  const sendEventMutation = useMutation({
+    mutationFn: (values: EventForm & { payload?: Record<string, unknown> | null }) =>
+      postPresenceEvent(values),
+    onSuccess: () => {
+      setEventMessage('Evento enviado y estado actualizado');
+      setEventError(null);
+      queryClient.invalidateQueries({ queryKey: ['status-now'] });
+      resetEvent({
+        person_id: '',
+        ts: nowLocal(),
+        source: 'biometric',
+        type: 'entry',
+        payload: '',
+      });
+    },
+  });
+
+  const statusTotals = useMemo(() => {
+    const items = statusQuery.data ?? [];
+    const totals = new Map<string, number>();
+    items.forEach((row) => {
+      const key = row.status ?? 'SIN_ESTADO';
+      totals.set(key, (totals.get(key) ?? 0) + 1);
+    });
+    return Array.from(totals.entries()).map(([status, count]) => ({ status, count }));
+  }, [statusQuery.data]);
+
+  const onCreatePerson = (values: PersonForm) => {
+    setPersonMessage(null);
+    createPersonMutation.mutate(values);
+  };
+
+  const onSendEvent = (values: EventForm) => {
+    setEventMessage(null);
+    let parsedPayload: Record<string, unknown> | null = null;
+    if (values.payload) {
+      try {
+        parsedPayload = JSON.parse(values.payload);
+      } catch (err) {
+        setEventError('La carga útil debe ser un JSON válido');
+        return;
+      }
+    }
+    setEventError(null);
+    const timestamp = new Date(values.ts);
+    if (Number.isNaN(timestamp.getTime())) {
+      setEventError('Ingresá un horario válido');
+      return;
+    }
+    const formattedTs = timestamp.toISOString();
+    sendEventMutation.mutate({
+      ...values,
+      ts: formattedTs,
+      payload: parsedPayload ?? undefined,
+    });
+  };
+
+  const statusRows: StatusRow[] = statusQuery.data ?? [];
+  const people: PersonRow[] = peopleQuery.data ?? [];
+
+  return (
+    <div className="space-y-8">
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Panel rápido</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Gestioná las operaciones básicas desde un único lugar. Podés dar de alta agentes,
+          simular eventos de presencia y revisar el estado en vivo sin navegar por todo el
+          menú.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3 text-sm">
+          <Link
+            to="/"
+            className="rounded border border-primary px-3 py-2 font-medium text-primary transition hover:bg-primary hover:text-white"
+          >
+            Ver dashboard completo
+          </Link>
+          <Link
+            to="/importar"
+            className="rounded border border-slate-300 px-3 py-2 text-slate-700 transition hover:bg-slate-100"
+          >
+            Importar personas por CSV
+          </Link>
+          <Link
+            to="/eventos"
+            className="rounded border border-slate-300 px-3 py-2 text-slate-700 transition hover:bg-slate-100"
+          >
+            Abrir sandbox avanzado
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-base font-semibold text-slate-900">Alta rápida de persona</h3>
+          <p className="mt-1 text-sm text-slate-600">
+            Registrá datos mínimos para empezar a monitorear a alguien. Podrás completar el
+            perfil luego desde la sección Personas.
+          </p>
+          <form className="mt-4 space-y-4" onSubmit={handleSubmitPerson(onCreatePerson)}>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="nombre">
+                Nombre y apellido
+              </label>
+              <input
+                id="nombre"
+                type="text"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Ej: Juana Pérez"
+                {...registerPerson('nombre')}
+              />
+              {personErrors.nombre && (
+                <p className="mt-1 text-xs text-red-600">{personErrors.nombre.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="rol">
+                Rol
+              </label>
+              <input
+                id="rol"
+                type="text"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Ej: Supervisor"
+                {...registerPerson('rol')}
+              />
+              {personErrors.rol && (
+                <p className="mt-1 text-xs text-red-600">{personErrors.rol.message}</p>
+              )}
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-slate-700" htmlFor="unidad">
+                  Unidad
+                </label>
+                <input
+                  id="unidad"
+                  type="text"
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder="Ej: Guardia Centro"
+                  {...registerPerson('unidad')}
+                />
+                {personErrors.unidad && (
+                  <p className="mt-1 text-xs text-red-600">{personErrors.unidad.message}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700" htmlFor="jerarquia">
+                  Jerarquía (opcional)
+                </label>
+                <input
+                  id="jerarquia"
+                  type="text"
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  placeholder="Ej: Senior"
+                  {...registerPerson('jerarquia')}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="especialidad">
+                Especialidad (opcional)
+              </label>
+              <input
+                id="especialidad"
+                type="text"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder="Ej: Primeros auxilios"
+                {...registerPerson('especialidad')}
+              />
+            </div>
+            {personMessage && <p className="text-sm text-green-600">{personMessage}</p>}
+            {createPersonMutation.isError && (
+              <p className="text-sm text-red-600">
+                No pudimos crear a la persona. Probá nuevamente en unos segundos.
+              </p>
+            )}
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              disabled={createPersonMutation.isPending}
+            >
+              {createPersonMutation.isPending ? 'Guardando…' : 'Crear y habilitar monitoreo'}
+            </button>
+          </form>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-base font-semibold text-slate-900">Evento inmediato</h3>
+          <p className="mt-1 text-sm text-slate-600">
+            Enviá un evento de presencia para actualizar el estado en tiempo real. Ideal para
+            pruebas o cargas manuales.
+          </p>
+          <form className="mt-4 space-y-4" onSubmit={handleSubmitEvent(onSendEvent)}>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="person_id">
+                Persona
+              </label>
+              <select
+                id="person_id"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                {...registerEvent('person_id')}
+              >
+                <option value="">Seleccioná una persona…</option>
+                {peopleQuery.isLoading && <option value="" disabled>Cargando personas…</option>}
+                {people.map((person) => (
+                  <option key={person.id} value={person.id}>
+                    {person.nombre} · {person.rol}
+                  </option>
+                ))}
+              </select>
+              {eventErrors.person_id && (
+                <p className="mt-1 text-xs text-red-600">{eventErrors.person_id.message}</p>
+              )}
+              {peopleQuery.isError && (
+                <p className="mt-1 text-xs text-red-600">
+                  No pudimos cargar las personas. Refrescá la página para reintentar.
+                </p>
+              )}
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="block text-sm font-medium text-slate-700" htmlFor="source">
+                  Origen
+                </label>
+                <select
+                  id="source"
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  {...registerEvent('source')}
+                >
+                  {sources.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {eventErrors.source && (
+                  <p className="mt-1 text-xs text-red-600">{eventErrors.source.message}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700" htmlFor="type">
+                  Tipo de evento
+                </label>
+                <select
+                  id="type"
+                  className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                  {...registerEvent('type')}
+                >
+                  {types.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {eventErrors.type && (
+                  <p className="mt-1 text-xs text-red-600">{eventErrors.type.message}</p>
+                )}
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="ts">
+                Momento (ISO 8601)
+              </label>
+              <input
+                id="ts"
+                type="datetime-local"
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                {...registerEvent('ts')}
+              />
+              {eventErrors.ts && (
+                <p className="mt-1 text-xs text-red-600">{eventErrors.ts.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="payload">
+                Detalles adicionales (JSON opcional)
+              </label>
+              <textarea
+                id="payload"
+                rows={3}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+                placeholder='{"geo":"Base Central"}'
+                {...registerEvent('payload')}
+              />
+              {eventError && <p className="mt-1 text-xs text-red-600">{eventError}</p>}
+            </div>
+            {eventErrors.payload && (
+              <p className="text-xs text-red-600">{eventErrors.payload.message}</p>
+            )}
+            {eventMessage && <p className="text-sm text-green-600">{eventMessage}</p>}
+            {sendEventMutation.isError && (
+              <p className="text-sm text-red-600">
+                No pudimos registrar el evento. Reintentá más tarde.
+              </p>
+            )}
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2"
+              disabled={sendEventMutation.isPending}
+            >
+              {sendEventMutation.isPending ? 'Enviando…' : 'Enviar evento y actualizar'}
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-slate-900">Estado en vivo</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Cada tarjeta muestra cuántas personas están en cada estado. La tabla inferior
+              detalla el último evento detectado.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            Última actualización: {statusQuery.isFetching ? 'actualizando…' : 'sincronizada'}
+          </div>
+        </div>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {statusTotals.length === 0 && !statusQuery.isLoading && !statusQuery.isError && (
+            <p className="col-span-full text-sm text-slate-500">
+              Aún no hay estados registrados. Enviá un evento para comenzar.
+            </p>
+          )}
+          {statusTotals.map((item) => (
+            <div key={item.status} className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                {item.status}
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-slate-900">{item.count}</p>
+            </div>
+          ))}
+          {statusQuery.isError && (
+            <p className="col-span-full text-sm text-red-600">
+              No pudimos obtener los estados en vivo. Intentá nuevamente más tarde.
+            </p>
+          )}
+        </div>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+            <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+              <tr>
+                <th scope="col" className="px-3 py-2">
+                  Persona
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Rol
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Unidad
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Estado
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Motivo
+                </th>
+                <th scope="col" className="px-3 py-2">
+                  Actualizado
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {statusRows.map((row) => (
+                <tr key={row.id}>
+                  <td className="px-3 py-2 font-medium text-slate-900">{row.nombre}</td>
+                  <td className="px-3 py-2 text-slate-600">{row.rol ?? '—'}</td>
+                  <td className="px-3 py-2 text-slate-600">{row.unidad ?? '—'}</td>
+                  <td className="px-3 py-2 font-semibold text-slate-900">{row.status ?? 'SIN_ESTADO'}</td>
+                  <td className="px-3 py-2 text-slate-600">{row.reason ?? 'Sin motivo registrado'}</td>
+                  <td className="px-3 py-2 text-slate-600">
+                    {row.ts ? new Date(row.ts).toLocaleString('es-AR') : '—'}
+                  </td>
+                </tr>
+              ))}
+              {statusRows.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-4 text-center text-sm text-slate-500">
+                    Todavía no hay datos disponibles.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default QuickPanel;

--- a/app/src/routes/Settings.tsx
+++ b/app/src/routes/Settings.tsx
@@ -1,0 +1,73 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { institutionSchema } from '../lib/validators';
+import { Label, Input, ErrorText } from '../components/FormControls';
+import { z } from 'zod';
+
+const Settings = () => {
+  const stored = localStorage.getItem('institution');
+  const defaultValues = stored ? (JSON.parse(stored) as z.infer<typeof institutionSchema>) : {
+    nombre: 'Institución Demo',
+    zonaHoraria: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    toleranciaNoShow: 15,
+    breakMax: 20,
+    prefijoLegajo: 'LEG',
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitSuccessful },
+  } = useForm<z.infer<typeof institutionSchema>>({
+    resolver: zodResolver(institutionSchema),
+    defaultValues,
+  });
+
+  const onSubmit = (values: z.infer<typeof institutionSchema>) => {
+    localStorage.setItem('institution', JSON.stringify(values));
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <h2 className="text-xl font-semibold">Configuración de la institución</h2>
+      <p className="text-sm text-slate-500">
+        Define los parámetros globales de operación. Los valores se almacenan en el navegador para esta demo.
+      </p>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="nombre">Nombre</Label>
+          <Input id="nombre" {...register('nombre')} />
+          <ErrorText message={errors.nombre?.message} />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="zonaHoraria">Zona horaria</Label>
+          <Input id="zonaHoraria" {...register('zonaHoraria')} />
+          <ErrorText message={errors.zonaHoraria?.message} />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="toleranciaNoShow">Tolerancia no-show (min)</Label>
+            <Input id="toleranciaNoShow" type="number" {...register('toleranciaNoShow', { valueAsNumber: true })} />
+            <ErrorText message={errors.toleranciaNoShow?.message} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="breakMax">Descanso máximo (min)</Label>
+            <Input id="breakMax" type="number" {...register('breakMax', { valueAsNumber: true })} />
+            <ErrorText message={errors.breakMax?.message} />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="prefijoLegajo">Prefijo de legajo</Label>
+          <Input id="prefijoLegajo" {...register('prefijoLegajo')} />
+          <ErrorText message={errors.prefijoLegajo?.message} />
+        </div>
+        <button type="submit" className="rounded bg-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-600">
+          Guardar cambios
+        </button>
+        {isSubmitSuccessful && <p className="text-sm text-success">Configuración guardada</p>}
+      </form>
+    </div>
+  );
+};
+
+export default Settings;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#0a7cff',
+        danger: '#f04438',
+        success: '#12b76a',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+  },
+});

--- a/backend-node/Dockerfile
+++ b/backend-node/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /usr/src/app
+COPY package.json package-lock.json* .npmrc* ./
+RUN npm install --production=false
+COPY src ./src
+COPY test ./test
+ENV NODE_ENV=production
+CMD ["node", "src/server.js"]

--- a/backend-node/package.json
+++ b/backend-node/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "control-personal-backend",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "seed": "node src/seed.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.5",
+    "ws": "^8.17.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1",
+    "nodemon": "^3.1.4"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "collectCoverage": false
+  }
+}

--- a/backend-node/src/db.js
+++ b/backend-node/src/db.js
@@ -1,0 +1,16 @@
+const { Pool } = require('pg');
+const dotenv = require('dotenv');
+dotenv.config();
+
+const connectionString = process.env.DB_URL || 'postgresql://app:app@localhost:5432/control_personal';
+
+const pool = new Pool({ connectionString });
+
+pool.on('error', (err) => {
+  console.error('DB error', err);
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  pool,
+};

--- a/backend-node/src/seed.js
+++ b/backend-node/src/seed.js
@@ -1,0 +1,25 @@
+const db = require('./db');
+
+const run = async () => {
+  try {
+    await db.query(`INSERT INTO person (id, nombre, rol, jerarquia, especialidad, unidad)
+      VALUES
+      ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Ana Fernández', 'Supervisor', 'Nivel 2', 'Operaciones', 'Unidad A'),
+      ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Bruno Díaz', 'Operador', 'Nivel 1', 'Soporte', 'Unidad A'),
+      ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Carla Gómez', 'Operador', 'Nivel 1', 'Seguridad', 'Unidad B')
+      ON CONFLICT (id) DO NOTHING`);
+
+    await db.query(`INSERT INTO status_snapshot (person_id, status, ts, source, reason)
+      VALUES
+      ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'AVAILABLE', NOW(), 'seed', 'Reseteado'),
+      ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'BUSY', NOW(), 'seed', 'Reseteado'),
+      ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'OFF_SHIFT', NOW(), 'seed', 'Reseteado')`);
+    console.log('Seeds aplicadas');
+  } catch (err) {
+    console.error('Error en seed', err);
+  } finally {
+    await db.pool.end();
+  }
+};
+
+run();

--- a/backend-node/src/server.js
+++ b/backend-node/src/server.js
@@ -1,0 +1,247 @@
+const express = require('express');
+require('express-async-errors');
+const cors = require('cors');
+const http = require('http');
+const jwt = require('jsonwebtoken');
+const dotenv = require('dotenv');
+const db = require('./db');
+const attachWebSocket = require('./ws');
+const { onEvent } = require('./stateEngine');
+
+dotenv.config();
+
+const PORT = process.env.PORT || 8080;
+const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const server = http.createServer(app);
+const ws = attachWebSocket(server);
+
+const authMiddleware = (req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header) return res.status(401).json({ message: 'Sin token' });
+  try {
+    const token = header.replace('Bearer ', '');
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.user = payload;
+    return next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Token inválido' });
+  }
+};
+
+app.post('/auth/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Credenciales incompletas' });
+  }
+  if (username !== 'admin@demo' || password !== 'admin') {
+    return res.status(401).json({ message: 'Credenciales inválidas' });
+  }
+  const token = jwt.sign({ username, role: 'admin' }, JWT_SECRET, { expiresIn: '8h' });
+  res.json({ token });
+});
+
+app.get('/health', async (req, res) => {
+  const start = Date.now();
+  await db.query('SELECT 1');
+  const latency = Date.now() - start;
+  res.json({ status: 'ok', latency_ms: latency, version: '1.0.0' });
+});
+
+app.get('/people', authMiddleware, async (req, res) => {
+  const { unit, role, status } = req.query;
+  const conditions = [];
+  const params = [];
+  if (unit) {
+    params.push(unit);
+    conditions.push(`unidad = $${params.length}`);
+  }
+  if (role) {
+    params.push(role);
+    conditions.push(`rol = $${params.length}`);
+  }
+  let baseQuery = 'SELECT * FROM person';
+  if (conditions.length) {
+    baseQuery += ` WHERE ${conditions.join(' AND ')}`;
+  }
+  baseQuery += ' ORDER BY nombre ASC';
+  const peopleResult = await db.query(baseQuery, params);
+
+  if (!status) {
+    return res.json({ data: peopleResult.rows });
+  }
+
+  const ids = peopleResult.rows.map((p) => p.id);
+  if (!ids.length) return res.json({ data: [] });
+  const statusResult = await db.query(
+    `SELECT DISTINCT ON (person_id) person_id, status, ts FROM status_snapshot WHERE person_id = ANY($1::uuid[]) ORDER BY person_id, ts DESC`,
+    [ids]
+  );
+  const statusMap = statusResult.rows.reduce((acc, row) => {
+    acc[row.person_id] = row;
+    return acc;
+  }, {});
+  const filtered = peopleResult.rows.filter((p) => statusMap[p.id]?.status === status);
+  res.json({ data: filtered });
+});
+
+app.post('/people', authMiddleware, async (req, res) => {
+  const { nombre, rol, jerarquia, especialidad, unidad } = req.body;
+  if (!nombre || !rol) {
+    return res.status(400).json({ message: 'Nombre y rol obligatorios' });
+  }
+  const insert = await db.query(
+    `INSERT INTO person (nombre, rol, jerarquia, especialidad, unidad) VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+    [nombre, rol, jerarquia || null, especialidad || null, unidad || null]
+  );
+  res.status(201).json(insert.rows[0]);
+});
+
+const getLatestSnapshot = async (personId) => {
+  const result = await db.query(
+    'SELECT * FROM status_snapshot WHERE person_id = $1 ORDER BY ts DESC LIMIT 1',
+    [personId]
+  );
+  return result.rows[0] || null;
+};
+
+const upsertSnapshot = async (snapshot) => {
+  const insert = await db.query(
+    `INSERT INTO status_snapshot (person_id, status, ts, source, reason) VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+    [snapshot.person_id, snapshot.status, snapshot.ts, snapshot.source, snapshot.reason]
+  );
+  return insert.rows[0];
+};
+
+const getShiftContext = async (personId, ts) => {
+  const context = { inShift: false, shiftEnded: false };
+  const result = await db.query(
+    `SELECT start_ts, end_ts FROM shift WHERE person_id = $1 ORDER BY end_ts DESC LIMIT 1`,
+    [personId]
+  );
+  if (!result.rowCount) {
+    context.shiftEnded = true;
+    return context;
+  }
+  const shift = result.rows[0];
+  const timestamp = new Date(ts);
+  context.inShift = timestamp >= new Date(shift.start_ts) && timestamp <= new Date(shift.end_ts);
+  const grace = 10 * 60 * 1000;
+  context.shiftEnded = timestamp > new Date(shift.end_ts).getTime() + grace;
+  return context;
+};
+
+const recordAudit = async (personId, action, details) => {
+  await db.query(
+    `INSERT INTO audit_log (person_id, action, details) VALUES ($1,$2,$3)` ,
+    [personId, action, details ? JSON.stringify(details) : '{}']
+  );
+};
+
+app.post('/events/presence', authMiddleware, async (req, res) => {
+  const { person_id, ts, source, type, payload } = req.body;
+  if (!person_id || !ts || !source || !type) {
+    return res.status(400).json({ message: 'Campos obligatorios: person_id, ts, source, type' });
+  }
+  const eventResult = await db.query(
+    `INSERT INTO presence_event (person_id, ts, source, type, payload) VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+    [person_id, ts, source, type, payload ? JSON.stringify(payload) : '{}']
+  );
+  const event = eventResult.rows[0];
+  const currentSnapshot = await getLatestSnapshot(person_id);
+  const context = await getShiftContext(person_id, ts);
+  const snapshotCandidate = onEvent(event, currentSnapshot, context);
+  let appliedSnapshot = currentSnapshot;
+  if (!currentSnapshot || snapshotCandidate.status !== currentSnapshot.status || snapshotCandidate.reason !== currentSnapshot.reason) {
+    appliedSnapshot = await upsertSnapshot(snapshotCandidate);
+    ws.broadcast(appliedSnapshot);
+    await recordAudit(person_id, 'status_change', { from: currentSnapshot?.status, to: appliedSnapshot.status, reason: appliedSnapshot.reason });
+  }
+  res.status(201).json({ event, snapshot: appliedSnapshot });
+});
+
+app.get('/status/now', authMiddleware, async (req, res) => {
+  const { unit } = req.query;
+  const result = await db.query(
+    `SELECT DISTINCT ON (p.id) p.id, p.nombre, p.rol, p.unidad, s.status, s.ts, s.reason
+     FROM person p
+     LEFT JOIN status_snapshot s ON s.person_id = p.id
+     ${unit ? 'WHERE p.unidad = $1' : ''}
+     ORDER BY p.id, s.ts DESC`,
+    unit ? [unit] : []
+  );
+  res.json({ data: result.rows });
+});
+
+app.get('/status/history', authMiddleware, async (req, res) => {
+  const { person_id, from, to } = req.query;
+  if (!person_id) return res.status(400).json({ message: 'person_id obligatorio' });
+  const params = [person_id];
+  const conditions = ['person_id = $1'];
+  if (from) {
+    params.push(from);
+    conditions.push(`ts >= $${params.length}`);
+  }
+  if (to) {
+    params.push(to);
+    conditions.push(`ts <= $${params.length}`);
+  }
+  const query = `SELECT person_id, status, ts, source, reason FROM status_snapshot WHERE ${conditions.join(' AND ')} ORDER BY ts DESC`;
+  const result = await db.query(query, params);
+  res.json({ data: result.rows });
+});
+
+app.post('/alerts/test', authMiddleware, async (req, res) => {
+  const { person_id, channel } = req.body;
+  if (!person_id) return res.status(400).json({ message: 'person_id requerido' });
+  await recordAudit(person_id, 'alert_test', { channel: channel || 'default' });
+  res.json({ message: 'Alerta de prueba enviada' });
+});
+
+app.get('/reports/kpi', authMiddleware, async (req, res) => {
+  const { from, to } = req.query;
+  const params = [];
+  const conditions = [];
+  if (from) {
+    params.push(from);
+    conditions.push(`ts >= $${params.length}`);
+  }
+  if (to) {
+    params.push(to);
+    conditions.push(`ts <= $${params.length}`);
+  }
+  let baseQuery = 'SELECT status FROM status_snapshot';
+  if (conditions.length) {
+    baseQuery += ` WHERE ${conditions.join(' AND ')}`;
+  }
+  const result = await db.query(baseQuery, params);
+  const totals = result.rows.reduce((acc, row) => {
+    acc[row.status] = (acc[row.status] || 0) + 1;
+    return acc;
+  }, {});
+  res.json({ totals });
+});
+
+app.get('/audit/:personId', authMiddleware, async (req, res) => {
+  const { personId } = req.params;
+  const result = await db.query(
+    `SELECT action, details, ts FROM audit_log WHERE person_id = $1 ORDER BY ts DESC LIMIT 100`,
+    [personId]
+  );
+  res.json({ data: result.rows });
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ message: 'Error inesperado', detail: err.message });
+});
+
+server.listen(PORT, () => {
+  console.log(`Backend escuchando en puerto ${PORT}`);
+});
+
+module.exports = { app, server };

--- a/backend-node/src/stateEngine.js
+++ b/backend-node/src/stateEngine.js
@@ -1,0 +1,101 @@
+const PRIORITIES = ['EMERGENCY', 'BIOMETRIC', 'GEOFENCE', 'TASK', 'CALENDAR'];
+const priorityWeight = PRIORITIES.reduce((acc, name, index) => {
+  acc[name] = PRIORITIES.length - index;
+  return acc;
+}, {});
+
+const inferPriority = (event) => {
+  if (!event) return 'CALENDAR';
+  if (event.type === 'panic' || event.source === 'panic') return 'EMERGENCY';
+  if (event.source === 'biometric') return 'BIOMETRIC';
+  if (event.type && event.type.startsWith('geo')) return 'GEOFENCE';
+  if (event.source === 'task') return 'TASK';
+  return 'CALENDAR';
+};
+
+const applyRules = (event, currentSnapshot = null, context = {}) => {
+  if (!event) return null;
+  const base = {
+    person_id: event.person_id,
+    ts: event.ts,
+    source: 'resolved',
+    reason: '',
+    status: currentSnapshot?.status || 'OFF_SHIFT',
+    priority: inferPriority(event),
+  };
+
+  if (event.type === 'panic') {
+    return { ...base, status: 'EMERGENCY', reason: 'Botón de pánico' };
+  }
+
+  if (event.source === 'biometric' && event.type === 'entry') {
+    return { ...base, status: 'ON_SHIFT', reason: 'Ingreso biométrico' };
+  }
+
+  if (event.source === 'biometric' && event.type === 'exit') {
+    return { ...base, status: 'OFF_SHIFT', reason: 'Salida biométrica' };
+  }
+
+  if (event.source === 'task' && event.type === 'assigned') {
+    return { ...base, status: 'BUSY', reason: 'Tarea asignada' };
+  }
+
+  if (event.source === 'task' && event.type === 'completed') {
+    return { ...base, status: 'AVAILABLE', reason: 'Tarea completada' };
+  }
+
+  if (event.source === 'mobile' && event.type === 'geo_enter') {
+    if (context.inShift) {
+      return { ...base, status: 'AVAILABLE', reason: 'Ingreso a zona geocercada' };
+    }
+    return { ...base, status: 'ON_SHIFT', reason: 'Ingreso fuera de turno' };
+  }
+
+  if (event.source === 'mobile' && event.type === 'geo_exit') {
+    return { ...base, status: 'BREAK', reason: 'Salida de zona geocercada' };
+  }
+
+  if (event.type === 'entry' || event.type === 'checkin') {
+    return { ...base, status: 'AVAILABLE', reason: 'Check-in' };
+  }
+
+  if (event.type === 'exit' || event.type === 'checkout') {
+    return { ...base, status: 'OFF_SHIFT', reason: 'Check-out' };
+  }
+
+  if (context.shiftEnded) {
+    return { ...base, status: 'OFF_SHIFT', reason: 'Fin de turno' };
+  }
+
+  return { ...base, status: currentSnapshot?.status || 'OFF_SHIFT', reason: 'Sin cambios' };
+};
+
+const chooseByPriority = (candidate, currentSnapshot) => {
+  if (!candidate) return currentSnapshot || null;
+  if (!currentSnapshot) return candidate;
+  const currentPriority = currentSnapshot.priority || inferPriority({ source: currentSnapshot.source });
+  const candidatePriority = candidate.priority || inferPriority({ source: candidate.source, type: candidate.type });
+  if ((priorityWeight[candidatePriority] || 0) > (priorityWeight[currentPriority] || 0)) {
+    return candidate;
+  }
+  if ((priorityWeight[candidatePriority] || 0) === (priorityWeight[currentPriority] || 0)) {
+    if (new Date(candidate.ts).getTime() >= new Date(currentSnapshot.ts).getTime()) {
+      return candidate;
+    }
+  }
+  return { ...currentSnapshot, priority: currentPriority };
+};
+
+const onEvent = (event, currentSnapshot, context) => {
+  const candidate = applyRules(event, currentSnapshot, context);
+  const chosen = chooseByPriority(candidate, currentSnapshot && { ...currentSnapshot, priority: currentSnapshot.priority || inferPriority({ source: currentSnapshot.source }) });
+  return chosen;
+};
+
+module.exports = {
+  PRIORITIES,
+  applyRules,
+  chooseByPriority,
+  onEvent,
+  inferPriority,
+};

--- a/backend-node/src/ws.js
+++ b/backend-node/src/ws.js
@@ -1,0 +1,22 @@
+const WebSocket = require('ws');
+
+const attachWebSocket = (server) => {
+  const wss = new WebSocket.Server({ server, path: '/ws/status' });
+
+  wss.on('connection', (ws) => {
+    ws.send(JSON.stringify({ type: 'welcome', ts: new Date().toISOString() }));
+  });
+
+  const broadcast = (payload) => {
+    const data = JSON.stringify({ type: 'status_update', payload });
+    wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(data);
+      }
+    });
+  };
+
+  return { broadcast };
+};
+
+module.exports = attachWebSocket;

--- a/backend-node/test/api.test.js
+++ b/backend-node/test/api.test.js
@@ -1,0 +1,24 @@
+jest.mock('../src/db', () => ({
+  query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+}));
+
+describe('API contract smoke', () => {
+  let app;
+  let supertest;
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'testsecret';
+    ({ app } = require('../src/server'));
+    supertest = require('supertest');
+  });
+
+  it('rejects missing credentials', async () => {
+    const response = await supertest(app).post('/auth/login').send({});
+    expect(response.status).toBe(400);
+  });
+
+  it('authenticates demo user', async () => {
+    const response = await supertest(app).post('/auth/login').send({ username: 'admin@demo', password: 'admin' });
+    expect(response.status).toBe(200);
+    expect(response.body.token).toBeDefined();
+  });
+});

--- a/backend-node/test/stateEngine.test.js
+++ b/backend-node/test/stateEngine.test.js
@@ -1,0 +1,18 @@
+const { onEvent } = require('../src/stateEngine');
+
+describe('state engine priority resolution', () => {
+  it('prioritises emergency events', () => {
+    const current = { person_id: '1', status: 'AVAILABLE', ts: '2024-01-01T10:00:00Z', source: 'resolved', reason: 'ok', priority: 'TASK' };
+    const event = { person_id: '1', ts: '2024-01-01T10:01:00Z', source: 'panic', type: 'panic' };
+    const result = onEvent(event, current, {});
+    expect(result.status).toBe('EMERGENCY');
+  });
+
+  it('keeps latest timestamp when same priority', () => {
+    const current = { person_id: '1', status: 'AVAILABLE', ts: '2024-01-01T10:00:00Z', source: 'resolved', reason: 'ok', priority: 'TASK' };
+    const event = { person_id: '1', ts: '2024-01-01T10:05:00Z', source: 'task', type: 'completed' };
+    const result = onEvent(event, current, {});
+    expect(result.status).toBe('AVAILABLE');
+    expect(result.ts).toBe('2024-01-01T10:05:00Z');
+  });
+});

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,63 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS site (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  nombre TEXT NOT NULL,
+  tipo TEXT NOT NULL,
+  zonas JSONB DEFAULT '[]'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS person (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  nombre TEXT NOT NULL,
+  rol TEXT NOT NULL,
+  jerarquia TEXT,
+  especialidad TEXT,
+  unidad TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS shift (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  person_id UUID REFERENCES person(id) ON DELETE CASCADE,
+  start_ts TIMESTAMPTZ NOT NULL,
+  end_ts TIMESTAMPTZ NOT NULL,
+  site_id UUID REFERENCES site(id),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS shift_person_idx ON shift(person_id);
+CREATE INDEX IF NOT EXISTS shift_start_idx ON shift(start_ts);
+
+CREATE TABLE IF NOT EXISTS presence_event (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  person_id UUID REFERENCES person(id) ON DELETE CASCADE,
+  ts TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL,
+  type TEXT NOT NULL,
+  payload JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS presence_event_person_idx ON presence_event(person_id);
+CREATE INDEX IF NOT EXISTS presence_event_ts_idx ON presence_event(ts);
+
+CREATE TABLE IF NOT EXISTS status_snapshot (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  person_id UUID REFERENCES person(id) ON DELETE CASCADE,
+  status TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL,
+  reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS status_snapshot_person_ts_idx ON status_snapshot(person_id, ts DESC);
+CREATE INDEX IF NOT EXISTS status_snapshot_person_idx ON status_snapshot(person_id);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  person_id UUID REFERENCES person(id) ON DELETE CASCADE,
+  action TEXT NOT NULL,
+  details JSONB DEFAULT '{}'::jsonb,
+  ts TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS audit_log_person_idx ON audit_log(person_id);
+

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,0 +1,20 @@
+INSERT INTO site (id, nombre, tipo, zonas) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'Base Central', 'oficina', '["Norte", "Sur"]');
+
+INSERT INTO person (id, nombre, rol, jerarquia, especialidad, unidad) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Ana Fernández', 'Supervisor', 'Nivel 2', 'Operaciones', 'Unidad A'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Bruno Díaz', 'Operador', 'Nivel 1', 'Soporte', 'Unidad A'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'Carla Gómez', 'Operador', 'Nivel 1', 'Seguridad', 'Unidad B')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO shift (id, person_id, start_ts, end_ts, site_id) VALUES
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', NOW() - INTERVAL '1 hour', NOW() + INTERVAL '7 hour', '11111111-1111-1111-1111-111111111111'),
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', NOW() - INTERVAL '30 minute', NOW() + INTERVAL '7 hour 30 minute', '11111111-1111-1111-1111-111111111111'),
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'cccccccc-cccc-cccc-cccc-cccccccccccc', NOW() - INTERVAL '3 hour', NOW() - INTERVAL '1 hour', '11111111-1111-1111-1111-111111111111')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO status_snapshot (id, person_id, status, ts, source, reason) VALUES
+  ('11111111-2222-3333-4444-555555555555', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'AVAILABLE', NOW() - INTERVAL '5 minute', 'seed', 'Inicio disponible'),
+  ('11111111-2222-3333-4444-666666666666', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'BUSY', NOW() - INTERVAL '10 minute', 'seed', 'Ticket asignado'),
+  ('11111111-2222-3333-4444-777777777777', 'cccccccc-cccc-cccc-cccc-cccccccccccc', 'OFF_SHIFT', NOW() - INTERVAL '1 hour', 'seed', 'Fin de turno')
+ON CONFLICT (id) DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: control_personal
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./db:/docker-entrypoint-initdb.d
+  backend-node:
+    build:
+      context: ./backend-node
+      dockerfile: Dockerfile
+    environment:
+      PORT: 8080
+      DB_URL: postgresql://app:app@postgres:5432/control_personal
+      JWT_SECRET: devsecret
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+  frontend:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    environment:
+      - VITE_API_BASE_URL=http://backend-node:8080
+    ports:
+      - "5173:80"
+    depends_on:
+      - backend-node

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,313 @@
+openapi: 3.0.3
+info:
+  title: Sistema General de Control de Personal
+  version: 1.0.0
+  description: API REST para gestionar personas, eventos y monitoreo en tiempo real.
+servers:
+  - url: http://localhost:8080
+paths:
+  /auth/login:
+    post:
+      summary: Iniciar sesión
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+              required: [username, password]
+      responses:
+        '200':
+          description: Token emitido
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        '401':
+          description: Credenciales inválidas
+  /people:
+    get:
+      summary: Listar personas
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: unit
+          schema:
+            type: string
+        - in: query
+          name: role
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/StatusEnum'
+      responses:
+        '200':
+          description: Listado de personas
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Person'
+    post:
+      summary: Crear persona
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonInput'
+      responses:
+        '201':
+          description: Persona creada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Person'
+  /events/presence:
+    post:
+      summary: Registrar evento de presencia
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PresenceEvent'
+            examples:
+              biometricEntry:
+                summary: Entrada biométrica
+                value:
+                  person_id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+                  ts: 2024-05-20T12:00:00Z
+                  source: biometric
+                  type: entry
+      responses:
+        '201':
+          description: Evento procesado
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event:
+                    $ref: '#/components/schemas/PresenceEvent'
+                  snapshot:
+                    $ref: '#/components/schemas/StatusSnapshot'
+  /status/now:
+    get:
+      summary: Estado actual
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: unit
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Estado actual por persona
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StatusNowItem'
+  /status/history:
+    get:
+      summary: Historial por persona
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: person_id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Historial de estados
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StatusSnapshot'
+  /alerts/test:
+    post:
+      summary: Enviar alerta de prueba
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                person_id:
+                  type: string
+                channel:
+                  type: string
+              required: [person_id]
+      responses:
+        '200':
+          description: Alerta enviada
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+  /reports/kpi:
+    get:
+      summary: Indicadores clave
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Totales por estado
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totals:
+                    type: object
+                    additionalProperties:
+                      type: integer
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Person:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        nombre:
+          type: string
+        rol:
+          type: string
+        jerarquia:
+          type: string
+          nullable: true
+        especialidad:
+          type: string
+          nullable: true
+        unidad:
+          type: string
+          nullable: true
+    PersonInput:
+      type: object
+      properties:
+        nombre:
+          type: string
+        rol:
+          type: string
+        jerarquia:
+          type: string
+        especialidad:
+          type: string
+        unidad:
+          type: string
+      required: [nombre, rol]
+    PresenceEvent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        person_id:
+          type: string
+        ts:
+          type: string
+          format: date-time
+        source:
+          type: string
+          enum: [mobile, kiosk, biometric, task, calendar, panic]
+        type:
+          type: string
+          enum: [entry, exit, checkin, checkout, assigned, completed, panic, geo_enter, geo_exit]
+        payload:
+          type: object
+          additionalProperties: true
+      required: [person_id, ts, source, type]
+    StatusSnapshot:
+      type: object
+      properties:
+        person_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/StatusEnum'
+        ts:
+          type: string
+          format: date-time
+        source:
+          type: string
+        reason:
+          type: string
+    StatusNowItem:
+      allOf:
+        - $ref: '#/components/schemas/Person'
+        - type: object
+          properties:
+            status:
+              $ref: '#/components/schemas/StatusEnum'
+            ts:
+              type: string
+              format: date-time
+            reason:
+              type: string
+    StatusEnum:
+      type: string
+      enum: [OFF_SHIFT, ON_SHIFT, AVAILABLE, BUSY, BREAK, ABSENT, TRAINING, ESCALATED, EMERGENCY]


### PR DESCRIPTION
## Summary
- add Docker-based infrastructure with PostgreSQL initialization, CI workflow, and project documentation for the control platform
- implement Express backend with WebSocket broadcasting, state engine, REST endpoints, and OpenAPI contract
- deliver React SPA for configuration, monitoring, CSV import, sandbox events, and diagnostics with Tailwind styling
- add a “Panel rápido” route in the SPA to centralize altas, eventos y estados en vivo sin depender de lanzadores externos

## Testing
- `npm test -- --runInBand` *(fails: jest missing because npm install is blocked by registry permissions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d985667ccc832fa719023890721cd9